### PR TITLE
Update twig/twig to 3.0 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": ">= 7.1.3",
         "composer-plugin-api": "^1.1",
         "composer/composer": "~1.7",
-        "twig/twig": "^2.12.1"
+        "twig/twig": "^2.12.1 || ^3.0"
     },
     "require-dev": {
         "drupol/php-conventions": "^1",


### PR DESCRIPTION
This PR allows for `twig/twig` `^3` alongside version 2. 

Passes built-in tests, and additional monkey testing by me. 🐵 🔨 
