### PR TITLE
Set `"composer/composer"` to `"^1 || ^2"`, now that Composer 2 has been released

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">= 7.1.3",
         "composer-plugin-api": "^1 || ^2",
-        "composer/composer": "dev-master",
+        "composer/composer": "^1 || ^2",
         "twig/twig": "^2.12.1 || ^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
Hi @drupol ,

We're working on getting Composer 2 support in Bolt. Could you please merge this and tag it? This Component seemt to work fine under Composer 2. 