### PR TITLE
Typo fix

### DIFF
--- a/src/Twig/VarExportExtension.php
+++ b/src/Twig/VarExportExtension.php
@@ -8,7 +8,7 @@ use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 
 /**
- * Class CamelCaseExtension.
+ * Class VarExportExtension.
  */
 final class VarExportExtension extends AbstractExtension
 {


### PR DESCRIPTION
This PR fixes a typo in a class's doc block.

* [x] 
* [ ] 
* [ ] 

Follows #.
Related to #.
Fixes #.
